### PR TITLE
Update consumer-rules.pro to keep images

### DIFF
--- a/flagkit/consumer-rules.pro
+++ b/flagkit/consumer-rules.pro
@@ -1,0 +1,2 @@
+# Needed to keep images
+-keep class com.murgupluoglu.flagkit.** { *; }


### PR DESCRIPTION
This PR configures consumer-rules.pro so images will be kept when R8 is enabled on applications.
This should solve #1 .